### PR TITLE
Fix dependencies/features ordering in generated Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,12 @@ dioxus-router = { version = "0.4" }
 {% endif %}
 {% endif %}
 
-log = "0.4.6"
+# Debug
+log = "0.4.19"
+dioxus-logger = "0.4.1"
+{% if platform == "web" %}
+console_error_panic_hook = "0.1.7"
+{% endif %}
 
 {% if platform == "Fullstack" %}
 [features]
@@ -73,11 +78,4 @@ web = ["dioxus-router/web", "dioxus-fullstack/web"]
 {% else %}
 web = ["dioxus-fullstack/web"]
 {% endif %}
-{% endif %}
-
-# Debug
-log = "0.4.19"
-dioxus-logger = "0.4.1"
-{% if platform == "web" %}
-console_error_panic_hook = "0.1.7"
 {% endif %}


### PR DESCRIPTION
I ran into this issue upon trying to generate a Fullstack project:
```
dx create
[WARN] You appear to be creating a Dioxus project from scratch; we will use the default config
[WARN] Favorite `gh:dioxuslabs/dioxus-template` not found in config, using it as a git repository: https://github.com/dioxuslabs/dioxus-template.git
🤷   Project Name: test
[INFO] 🔧   Destination: /Users/s1g/Workspaces/Dioxus/test ...
[INFO] 🔧   project-name: test ...
[INFO] 🔧   Generating template ...
✔ 🤷   Should the application use the dioxus router? · true
✔ 🤷   What platform are you targeting? · Fullstack
✔ 🤷   What backend framework are you using? · Axum
✔ 🤷   How do you want to create CSS? · Vanilla
[INFO] 🔧   Moving generated files into: `/Users/s1g/Workspaces/Dioxus/test`...
[INFO] Initializing a fresh Git repository
[INFO] ✨   Done! New project created /Users/s1g/Workspaces/Dioxus/test
[ERROR] cargo fmt failed
[ERROR] stdout:
[ERROR] stderr: `cargo metadata` exited with an error: error: failed to parse manifest at `/Users/s1g/Workspaces/Dioxus/test/Cargo.toml`

Caused by:
  invalid type: string "0.4.1", expected a sequence
  in `features.dioxus-logger`

This utility formats all bin and lib files of the current crate using rustfmt.

Usage: cargo fmt [OPTIONS] [-- <rustfmt_options>...]

Arguments:
  [rustfmt_options]...  Options passed to rustfmt

Options:
  -q, --quiet
          No output printed to stdout
  -v, --verbose
          Use verbose output
      --version
          Print rustfmt version and exit
  -p, --package <package>...
          Specify package to format
      --manifest-path <manifest-path>
          Specify path to Cargo.toml
      --message-format <message-format>
          Specify message-format: short|json|human
      --all
          Format all packages, and also their local path-based dependencies
      --check
          Run rustfmt in check mode
  -h, --help
          Print help

[INFO] Generated project at /Users/s1g/Workspaces/Dioxus/test
```

Turns out the latter half of the `Cargo.toml` template inserts dependencies after the `[dependencies]` section ends and the optional (only included if fullstack is selected) `[features]` section begins.

This can be fixed by moving the dependencies following the `# Debug` comment up before the optional fullstack `[features]`.