### PR TITLE
Add missing endifs such that README.md template parses properly

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,3 +46,5 @@ cargo run
 ```
 {% endif %}
 {% endif %}
+{% endif %}
+{% endif %}


### PR DESCRIPTION
I'm not sure why `cargo-generate` doesn't fail or even warn about this, but two of the beginning if branches in `README.md` aren't terminated properly, causing the "generated" readme to be the exact same as the template file including all of the placeholders. I assume this was an oversight so added the missing `endif`s. 

Closes #7.