### PR TITLE
Change default platform to desktop if selected + better title

### DIFF
--- a/Dioxus.toml
+++ b/Dioxus.toml
@@ -4,8 +4,12 @@
 name = "{{project-name}}"
 
 # Dioxus App Default Platform
-# desktop, web, mobile, ssr
+# desktop, web
+{% if platform == "desktop" %}
+default_platform = "desktop"
+{% else %}
 default_platform = "web"
+{% endif %}
 
 # `build` & `serve` dist path
 out_dir = "dist"
@@ -16,7 +20,7 @@ asset_dir = "public"
 [web.app]
 
 # HTML title tag content
-title = "dioxus | ⛺"
+title = "{{project-name}}"
 
 [web.watcher]
 


### PR DESCRIPTION
- Changes the `default_platform` value in `Dioxus.toml` to `"desktop"`, if that's the selected platform, otherwise leaves it `"web"`.
- Changes the title to the project name instead of "dioxus".