### PR TITLE
Fix desktop tailwind link when run with dioxus cli

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -166,7 +166,7 @@ fn main() {
     // Init debug
     dioxus_logger::init(LevelFilter::Info).expect("failed to init logger");
     {% if styling == "Tailwind" %}
-    dioxus_desktop::launch_cfg(app, dioxus_desktop::Config::new().with_custom_head(r#"<link rel="stylesheet" href="public/tailwind.css">"#.to_string()));
+    dioxus_desktop::launch_cfg(app, dioxus_desktop::Config::new().with_custom_head(r#"<link rel="stylesheet" href="tailwind.css">"#.to_string()));
     {% else %}
     dioxus_desktop::launch(app);
     {% endif %}


### PR DESCRIPTION
If you run a desktop applicaiton with the dioxus cli, it runs it from a different path than cargo run does. https://github.com/DioxusLabs/dioxus/pull/1369 fixes that issue. Until that is merged and published, this fixes the link to the tailwind file on the desktop tailwind template when running with the recommended `dx serve` command