### PR TITLE
Remove incremental rendering from the Fullstack template

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -184,25 +184,9 @@ fn main() {
     // Init debug
     dioxus_logger::init(LevelFilter::Info).expect("failed to init logger");
     {% if router %}
-    let config = LaunchBuilder::<FullstackRouterConfig<Route>>::router();
-    #[cfg(feature = "ssr")]
-    let config = config
-        .incremental(
-            IncrementalRendererConfig::default()
-                .invalidate_after(std::time::Duration::from_secs(120)),
-        );
-
-    config.launch();
+    LaunchBuilder::<FullstackRouterConfig<Route>>::router().launch();
     {% else %}
-    let config = LaunchBuilder::new(app);
-    #[cfg(feature = "ssr")]
-    let config = config
-        .incremental(
-            IncrementalRendererConfig::default()
-                .invalidate_after(std::time::Duration::from_secs(120)),
-        );
-
-    config.launch();
+    LaunchBuilder::new(app).launch();
     {% endif %}
 }
 {% endif %}


### PR DESCRIPTION
This PR simplifies the fullstack template by removing incremental rendering. The caching incremental rendering enables can be confusing if you want to react to real time changes which can make the dioxus server seem slow. The server should be fast enough without it, so it should be opt-in.

For the published version of dioxus, this will also prevent the issue in https://github.com/DioxusLabs/dioxus/pull/1741