### PR TITLE
More consistent `platform` values in `cargo-generate.toml`

### DIFF
--- a/cargo-generate.toml
+++ b/cargo-generate.toml
@@ -9,7 +9,7 @@ dioxus_version = "0.3"
 [placeholders.platform]
 type = "string"
 prompt = "What platform are you targeting?"
-choices = ["desktop", "web", "TUI", "Liveview", "Fullstack"]
+choices = ["web", "fullstack", "desktop", "liveview", "TUI"]
 default = "web"
 
 [conditional.'platform == "Liveview"'.placeholders.backend]


### PR DESCRIPTION
Made all values lowercase except `TUI`. Also sorted values in frequency-based order (half-subjective) with the default value as the first.

Fixes #23.