### PR TITLE
fix: tailwind load problem on non root routes

### DIFF
--- a/Web/Dioxus.toml
+++ b/Web/Dioxus.toml
@@ -31,7 +31,7 @@ watch_path = ["src", "assets"]
 
 # CSS style file
 {% if styling == "Tailwind" %}
-style = ["tailwind.css"]
+style = ["/tailwind.css"]
 {% else %}
 style = []
 {% endif %}


### PR DESCRIPTION
Hello,

I just started a web project with Dioxus. I ran ```dx new``` and started with the template. However, I encountered an issue when trying to use my CSS files in other routes than root.

# Problem
The CSS worked on root http://localhost:8080/ and found the Tailwind CSS on http://localhost:8080/tailwind.css. 

However, the CSS didn't work on http://localhost:8080/tool/add_commas because it was trying to locate the Tailwind file at http://localhost:8080/tools/tailwind.css, and there was no ```tailwind.css``` in ```./assets/tool/tailwind.css```, which caused it to break.

# Solution
I managed to fix the problem by adding a ```/``` in Dioxus.toml before tailwind.css (and my own css file). So, I decided to create a pull request for this fix.

# More
I'm excited about contributing to Dioxus, my favorite web framework.
If there are any issues with my PR, please let me know.
Lastly, should I apply the same change to the Desktop and FullStack templates?
Thanks for your attention and feedback!