### PR TITLE
Update `dioxus-logger`

### DIFF
--- a/Desktop/Cargo.toml
+++ b/Desktop/Cargo.toml
@@ -16,5 +16,4 @@ dioxus = { version = "0.5", features = ["desktop"] }
 
 
 # Debug
-tracing = "0.1.40"
-dioxus-logger = "0.5.0"
+dioxus-logger = "0.5.1"

--- a/Desktop/src/main.rs
+++ b/Desktop/src/main.rs
@@ -1,7 +1,7 @@
 #![allow(non_snake_case)]
 
 use dioxus::prelude::*;
-use tracing::Level;
+use dioxus_logger::tracing::{Level, info};
 {% if router %}
 #[derive(Clone, Routable, Debug, PartialEq)]
 enum Route {
@@ -15,6 +15,7 @@ enum Route {
 fn main() {
     // Init logger
     dioxus_logger::init(Level::INFO).expect("failed to init logger");
+    info!("starting app");
     {% if styling == "Tailwind" %}
     let cfg = dioxus::desktop::Config::new().with_custom_head(r#"<link rel="stylesheet" href="tailwind.css">"#.to_string());
     LaunchBuilder::desktop().with_cfg(cfg).launch(App);

--- a/Fullstack/Cargo.toml
+++ b/Fullstack/Cargo.toml
@@ -15,8 +15,7 @@ dioxus = { version = "0.5", features = ["fullstack"] }
 {% endif %}
 
 # Debug
-tracing = "0.1.40"
-dioxus-logger = "0.5.0"
+dioxus-logger = "0.5.1"
 
 [features]
 default = []

--- a/Fullstack/src/main.rs
+++ b/Fullstack/src/main.rs
@@ -1,7 +1,7 @@
 #![allow(non_snake_case)]
 
 use dioxus::prelude::*;
-use tracing::{Level, info};
+use dioxus_logger::tracing::{Level, info};
 
 {% if router %}
 #[derive(Clone, Routable, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
@@ -16,6 +16,7 @@ enum Route {
 fn main() {
     // Init logger
     dioxus_logger::init(Level::INFO).expect("failed to init logger");
+    info!("starting app");
     launch(App);
 }
 
@@ -53,7 +54,7 @@ fn Home() -> Element {
             button {
                 onclick: move |_| async move {
                     if let Ok(data) = get_server_data().await {
-                        tracing::info!("Client received: {}", data);
+                        info!("Client received: {}", data);
                         text.set(data.clone());
                         post_server_data(data).await.unwrap();
                     }

--- a/Liveview/Cargo.toml
+++ b/Liveview/Cargo.toml
@@ -18,5 +18,4 @@ axum = { version = "0.7.4", features = ["ws"] }
 {% endif %}
 
 # Debug
-tracing = "0.1.40"
-dioxus-logger = "0.5.0"
+dioxus-logger = "0.5.1"

--- a/Liveview/src/main.rs
+++ b/Liveview/src/main.rs
@@ -1,7 +1,7 @@
 #![allow(non_snake_case)]
 
 use dioxus::prelude::*;
-use tracing::Level;
+use dioxus_logger::tracing::{Level, info};
 {% if router %}
 #[derive(Clone, Routable, Debug, PartialEq)]
 enum Route {
@@ -15,6 +15,7 @@ enum Route {
 fn main() {
     // Init logger
     dioxus_logger::init(Level::INFO).expect("failed to init logger");
+    info!("starting app");
     launch(App);
 }
 

--- a/Web/Cargo.toml
+++ b/Web/Cargo.toml
@@ -16,5 +16,4 @@ dioxus = { version = "0.5", features = ["web"] }
 
 
 # Debug
-tracing = "0.1.40"
-dioxus-logger = "0.5.0"
+dioxus-logger = "0.5.1"

--- a/Web/src/main.rs
+++ b/Web/src/main.rs
@@ -1,7 +1,7 @@
 #![allow(non_snake_case)]
 
 use dioxus::prelude::*;
-use tracing::Level;
+use dioxus_logger::tracing::{Level, info};
 {% if router %}
 #[derive(Clone, Routable, Debug, PartialEq)]
 enum Route {
@@ -15,6 +15,7 @@ enum Route {
 fn main() {
     // Init logger
     dioxus_logger::init(Level::INFO).expect("failed to init logger");
+    info!("starting app");
     launch(App);
 }
 


### PR DESCRIPTION
`dioxus-logger` now reexports the tracing crate so it is no longer needed as a dependency. Adds some basic usage to logging (some info! here and there)

~~Waiting on https://github.com/DogeDark/dioxus-logger/pull/5~~