### PR TITLE
Don't enable a default renderer feature in the fullstack template

### DIFF
--- a/Bare-Bones/Cargo.toml
+++ b/Bare-Bones/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2021"
 dioxus = { {{ dioxus_dep_src }}, features = {{dioxus_dep_features}} }
 
 [features]
-default = ["{{default_platform}}"]
+default = [{% if is_fullstack == false -%}"{{default_platform}}"{%- endif %}]
 {%- for feature in features %}
 {{ feature }}
 {%- endfor %}

--- a/Bare-Bones/README.md
+++ b/Bare-Bones/README.md
@@ -17,9 +17,15 @@ npx tailwindcss -i ./input.css -o ./assets/tailwind.css --watch
 
 Run the following command in the root of your project to start developing with the default platform:
 
+{% if is_fullstack -%}
+```bash
+dx serve --platform {{default_platform}}
+```
+{%- else -%}
 ```bash
 dx serve
 ```
+{%- endif %}
 
 To run for a different platform, use the `--platform platform` flag. E.g.
 ```bash

--- a/Jumpstart/Cargo.toml
+++ b/Jumpstart/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2021"
 dioxus = { {{ dioxus_dep_src }}, features = {{dioxus_dep_features}} }
 
 [features]
-default = ["{{default_platform}}"]
+default = [{% if is_fullstack == false -%}"{{default_platform}}"{%- endif %}]
 {%- for feature in features %}
 {{ feature }}
 {%- endfor %}

--- a/Jumpstart/README.md
+++ b/Jumpstart/README.md
@@ -18,9 +18,15 @@ npx tailwindcss -i ./input.css -o ./assets/styling/tailwind.css --watch
 
 Run the following command in the root of your project to start developing with the default platform:
 
+{% if is_fullstack -%}
+```bash
+dx serve --platform {{default_platform}}
+```
+{%- else -%}
 ```bash
 dx serve
 ```
+{%- endif %}
 
 To run for a different platform, use the `--platform platform` flag. E.g.
 ```bash

--- a/Workspace/desktop/Cargo.toml
+++ b/Workspace/desktop/Cargo.toml
@@ -8,7 +8,7 @@ dioxus = { workspace = true, features = [{{- router_feature -}}] }
 ui = { workspace = true }
 
 [features]
-default = ["desktop"]
+default = [{% if is_fullstack == false -%}"desktop"{%- endif %}]
 desktop = ["dioxus/desktop"]
 {% if is_fullstack -%}
 server = ["dioxus/server"]

--- a/Workspace/mobile/Cargo.toml
+++ b/Workspace/mobile/Cargo.toml
@@ -8,7 +8,7 @@ dioxus = { workspace = true, features = [{{- router_feature -}}] }
 ui = { workspace = true }
 
 [features]
-default = ["mobile"]
+default = [{% if is_fullstack == false -%}"mobile"{%- endif %}]
 mobile = ["dioxus/mobile"]
 {% if is_fullstack -%}
 server = ["dioxus/server"]

--- a/Workspace/web/Cargo.toml
+++ b/Workspace/web/Cargo.toml
@@ -8,7 +8,7 @@ dioxus = { workspace = true, features = [{{- router_feature -}}] }
 ui = { workspace = true }
 
 [features]
-default = ["web"]
+default = [{% if is_fullstack == false -%}"web"{%- endif %}]
 web = ["dioxus/web"]
 {% if is_fullstack -%}
 server = ["dioxus/server"]

--- a/common.rhai
+++ b/common.rhai
@@ -26,6 +26,7 @@ let platforms = [
     "Desktop",
     "Mobile"
 ];
+let is_fullstack = variable::get(IS_FULLSTACK_VAR);
 
 // Do we need a default platform?
 if variable::get(NEEDS_DEFAULT_PLATFORM_VAR) {
@@ -64,7 +65,6 @@ if variable::get(NEEDS_DEFAULT_PLATFORM_VAR) {
 
 
 let is_router = variable::get(IS_ROUTER_VAR);
-let is_fullstack = variable::get(IS_FULLSTACK_VAR);
 switch [is_router, is_fullstack] {
     [true, true] => variable::set(DIOXUS_DEP_FEAT_VAR, "[\"router\", \"fullstack\"]"),
     [true, false] => variable::set(DIOXUS_DEP_FEAT_VAR, "[\"router\"]"),


### PR DESCRIPTION
The template currently enables the feature for the client side of the renderer that is selected as the default. When fullstack is enabled, this causes client side code to be run on the server. Several people in the discord have run into this issue. This PR removes the default platform from the template if fullstack is enabled. The default platform should probably be restored as a CLI setting in the future

Fixes #55