### PR TITLE
add bundle.identifier to Dioxus.toml templates

### DIFF
--- a/Desktop/Dioxus.toml
+++ b/Desktop/Dioxus.toml
@@ -13,6 +13,9 @@ out_dir = "dist"
 # assets file folder
 asset_dir = "assets"
 
+[bundle]
+identifier = "{{project-name}}"
+
 [web.app]
 
 # HTML title tag content

--- a/Fullstack/Dioxus.toml
+++ b/Fullstack/Dioxus.toml
@@ -13,6 +13,9 @@ out_dir = "dist"
 # resource (assets) file folder
 asset_dir = "assets"
 
+[bundle]
+identifier = "{{project-name}}"
+
 [web.app]
 
 # HTML title tag content

--- a/Liveview/Dioxus.toml
+++ b/Liveview/Dioxus.toml
@@ -13,6 +13,9 @@ out_dir = "dist"
 # resource (assets) file folder
 asset_dir = "assets"
 
+[bundle]
+identifier = "{{project-name}}"
+
 [web.app]
 
 # HTML title tag content

--- a/Web/Dioxus.toml
+++ b/Web/Dioxus.toml
@@ -13,6 +13,9 @@ out_dir = "dist"
 # resource (assets) file folder
 asset_dir = "assets"
 
+[bundle]
+identifier = "{{project-name}}"
+
 [web.app]
 
 # HTML title tag content


### PR DESCRIPTION
which is required to use Wix bundle tool on windows.

----

```shell
Windows Installer XML Toolset Compiler version 3.14.1.8722
Copyright (c) .NET Foundation and contributors. All rights reserved.

main.wxs
main.wxs(15) : error CNDL0006 : The Product/@Manufacturer attribute's value cannot be an empty string. If a value is not required, simply remove the entire attribute.
```
( The above output is swallowed by tauri-bundler crate, or by candle.exe of Wix. You must run candle.exe manually to get that error. see https://github.com/DioxusLabs/dioxus/issues/3233 )

```xml
<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
    <Product
            Id="*"
            Name="Myhotdog"
            UpgradeCode="bdb29162-5cc6-5e37-8cd0-c3819fab0bcf"
            Language="!(loc.TauriLanguage)"
            Manufacturer=""
            Version="0.1.0">
```

----

```rs
pub struct BundleSettings {
  /// the app's identifier.
  pub identifier: Option<String>,

  /// The app's publisher. Defaults to the second element in the identifier string.
  ///
  /// Currently maps to the Manufacturer property of the Windows Installer
  /// and the Maintainer field of debian packages if the Cargo.toml does not have the authors field.
  pub publisher: Option<String>,
  ......
```

The Product/@Manufacturer comes from BundleSettings.publisher, which in turn comes from BundleSettings.identifier as fallback.  See also the source https://docs.rs/crate/tauri-bundler/2.0.4/source/src/bundle/windows/msi/mod.rs#575-578
