### PR TITLE
fix: add default_platform to generated Dioxus config

### DIFF
--- a/Bare-Bones/Dioxus.toml
+++ b/Bare-Bones/Dioxus.toml
@@ -2,6 +2,7 @@
 
 # App (Project) Name
 name = "{{project-name}}"
+default_platform = "{{default_platform}}"
 
 [web.app]
 

--- a/Jumpstart/Dioxus.toml
+++ b/Jumpstart/Dioxus.toml
@@ -2,6 +2,7 @@
 
 # App (Project) Name
 name = "{{project-name}}"
+default_platform = "{{default_platform}}"
 
 [web.app]
 


### PR DESCRIPTION
the default platform was being asked for but was not added to the `Dioxus.toml` config. this fixes that