### PR TITLE
fix: use correct logic to apply default platform to Cargo.toml

### DIFF
--- a/Bare-Bones/Cargo.toml
+++ b/Bare-Bones/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2021"
 dioxus = { {{ dioxus_dep_src }}, features = {{dioxus_dep_features}} }
 
 [features]
-default = [{% if is_fullstack == false -%}"{{default_platform}}"{%- endif %}]
+default = [{% if is_fullstack -%}"{{default_platform}}"{%- endif %}]
 {%- for feature in features %}
 {{ feature }}
 {%- endfor %}

--- a/Jumpstart/Cargo.toml
+++ b/Jumpstart/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2021"
 dioxus = { {{ dioxus_dep_src }}, features = {{dioxus_dep_features}} }
 
 [features]
-default = [{% if is_fullstack == false -%}"{{default_platform}}"{%- endif %}]
+default = [{% if is_fullstack -%}"{{default_platform}}"{%- endif %}]
 {%- for feature in features %}
 {{ feature }}
 {%- endfor %}


### PR DESCRIPTION
updated the logic in the `Cargo.toml` files to add the default platform if the default platform variable **is set**. this logic was backwards and i believe the intention was to include a default platform as the default feature when fullstack is being used.