### PR TITLE
add windows-subsystem configuration for desktop platform

### DIFF
--- a/Desktop/src/main.rs
+++ b/Desktop/src/main.rs
@@ -1,4 +1,5 @@
 #![allow(non_snake_case)]
+#![cfg_attr(all(feature = "desktop", not(debug_assertions)), windows_subsystem = "windows")]
 
 use dioxus::prelude::*;
 use dioxus_logger::tracing::{Level, info};

--- a/Fullstack/src/main.rs
+++ b/Fullstack/src/main.rs
@@ -1,4 +1,5 @@
 #![allow(non_snake_case)]
+#![cfg_attr(all(feature = "desktop", not(debug_assertions)), windows_subsystem = "windows")]
 
 use dioxus::prelude::*;
 use dioxus_logger::tracing;

--- a/Liveview/src/main.rs
+++ b/Liveview/src/main.rs
@@ -1,4 +1,5 @@
 #![allow(non_snake_case)]
+#![cfg_attr(all(feature = "desktop", not(debug_assertions)), windows_subsystem = "windows")]
 
 use dioxus::prelude::*;
 use dioxus_logger::tracing::{Level, info};

--- a/Web/src/main.rs
+++ b/Web/src/main.rs
@@ -1,4 +1,5 @@
 #![allow(non_snake_case)]
+#![cfg_attr(all(feature = "desktop", not(debug_assertions)), windows_subsystem = "windows")]
 
 use dioxus::prelude::*;
 use dioxus_logger::tracing::{Level, info};


### PR DESCRIPTION
to remove the console window on startup for windows desktop/GUI applications.