### PR TITLE
Change the version to the major release instead of patch release

### DIFF
--- a/common.rhai
+++ b/common.rhai
@@ -1,7 +1,7 @@
 // Dioxus version. This only needs changed to update all templates.
 // You can change this in development to be `path = "abc/"` or `git = "xyz"` for local development.
 const DIOXUS_DEP_SRC_VAR = "dioxus_dep_src";
-variable::set(DIOXUS_DEP_SRC_VAR, "version = \"0.6.0\"");
+variable::set(DIOXUS_DEP_SRC_VAR, "version = \"0.6\"");
 
 // These are variables that are used in liquid
 const NEEDS_DEFAULT_PLATFORM_VAR = "needs_default_platform";


### PR DESCRIPTION
Hey, the tool you built is great!

I noticed however that the version of dioxus is at the first patch release of `v0.6.0` meaning since `v0.6.2` is now available I think it might be better to specify the version number only to the major release: `v0.6` that way cargo will select the latest patch release.