### PR TITLE
Add clippy config to prevent holding dioxus locks over await points

### DIFF
--- a/Bare-Bones/clippy.toml
+++ b/Bare-Bones/clippy.toml
@@ -1,0 +1,8 @@
+await-holding-invalid-types = [
+  "generational_box::GenerationalRef",
+  { path = "generational_box::GenerationalRef", reason = "Reads should not be held over an await point. This will cause any writes to fail while the await is pending since the read borrow is still active." },
+  "generational_box::GenerationalRefMut",
+  { path = "generational_box::GenerationalRefMut", reason = "Write should not be held over an await point. This will cause any reads or writes to fail while the await is pending since the write borrow is still active." },
+  "dioxus_signals::Write",
+  { path = "dioxus_signals::Write", reason = "Write should not be held over an await point. This will cause any reads or writes to fail while the await is pending since the write borrow is still active." },
+]

--- a/Jumpstart/clippy.toml
+++ b/Jumpstart/clippy.toml
@@ -1,0 +1,8 @@
+await-holding-invalid-types = [
+  "generational_box::GenerationalRef",
+  { path = "generational_box::GenerationalRef", reason = "Reads should not be held over an await point. This will cause any writes to fail while the await is pending since the read borrow is still active." },
+  "generational_box::GenerationalRefMut",
+  { path = "generational_box::GenerationalRefMut", reason = "Write should not be held over an await point. This will cause any reads or writes to fail while the await is pending since the write borrow is still active." },
+  "dioxus_signals::Write",
+  { path = "dioxus_signals::Write", reason = "Write should not be held over an await point. This will cause any reads or writes to fail while the await is pending since the write borrow is still active." },
+]

--- a/Workspace/clippy.toml
+++ b/Workspace/clippy.toml
@@ -1,0 +1,8 @@
+await-holding-invalid-types = [
+  "generational_box::GenerationalRef",
+  { path = "generational_box::GenerationalRef", reason = "Reads should not be held over an await point. This will cause any writes to fail while the await is pending since the read borrow is still active." },
+  "generational_box::GenerationalRefMut",
+  { path = "generational_box::GenerationalRefMut", reason = "Write should not be held over an await point. This will cause any reads or writes to fail while the await is pending since the write borrow is still active." },
+  "dioxus_signals::Write",
+  { path = "dioxus_signals::Write", reason = "Write should not be held over an await point. This will cause any reads or writes to fail while the await is pending since the write borrow is still active." },
+]


### PR DESCRIPTION
Clippy lets us define custom types that should not be held over await points. This PR adds a set of those types that are common in dioxus. This makes clippy warn about all of these cases:
```rust
use dioxus::prelude::*;

fn main() {
    launch(|| {
        let mut state = use_signal(|| 0);
        let mut boxed = use_hook(|| CopyValue::new(0));
        rsx! {
            button {
                onclick: move |_| async move {
                    let read = state.read();
                    other(&read).await;
                }
            }

            button {
                onclick: move |_| async move {
                    let mut write = state.write();
                    other_mut(&mut write).await;
                }
            }

            button {
                onclick: move |_| async move {
                    let read = boxed.read();
                    other(&read).await;
                }
            }

            button {
                onclick: move |_| async move {
                    let mut write = boxed.write();
                    other_mut(&mut write).await;
                }
            }
        }
    })
}

async fn other(value: &u32) {
    println!("value: {value}");
}

async fn other_mut(value: &mut u32) {
    *value += 1;
}
```

Pulled out from https://github.com/DioxusLabs/dioxus/issues/4124

