### PR TITLE
Update v0.7 template to v0.7.0-alpha.3

### DIFF
--- a/common.rhai
+++ b/common.rhai
@@ -1,7 +1,7 @@
 // Dioxus version. This only needs changed to update all templates.
 // You can change this in development to be `path = "abc/"` or `git = "xyz"` for local development.
 const DIOXUS_DEP_SRC_VAR = "dioxus_dep_src";
-variable::set(DIOXUS_DEP_SRC_VAR, "version = \"0.7.0-alpha.2\"");
+variable::set(DIOXUS_DEP_SRC_VAR, "version = \"0.7.0-alpha.3\"");
 
 // These are variables that are used in liquid
 const NEEDS_DEFAULT_PLATFORM_VAR = "needs_default_platform";


### PR DESCRIPTION
When writing the `dx new -y` command for https://github.com/DioxusLabs/dioxus/issues/4444, I found that even though the `dx` is alpha.3, the result directory has alpha.2.

Would be cool if `dx` can use/write its own version.
