### PR TITLE
Add a server feature for fullstack templates

### DIFF
--- a/common.rhai
+++ b/common.rhai
@@ -63,6 +63,10 @@ if variable::get(NEEDS_DEFAULT_PLATFORM_VAR) {
     }
 }
 
+// Add a server feature if the fullstack feature is enabled
+if is_fullstack {
+    features.push("server = [\"dioxus/server\"]");
+}
 
 let is_router = variable::get(IS_ROUTER_VAR);
 switch [is_router, is_fullstack] {


### PR DESCRIPTION
Adds a `server = ["dioxus/server"]` feature to the template if the fullstack option was selected to make it easier to later add fullstack only dependancies like tokio

Closes https://github.com/DioxusLabs/dioxus/issues/4598