### PR TITLE
Add the bundle flag to desktop apps to hide the windows console

### DIFF
--- a/Bare-Bones/Cargo.toml
+++ b/Bare-Bones/Cargo.toml
@@ -11,6 +11,7 @@ dioxus = { {{ dioxus_dep_src }}, features = {{dioxus_dep_features}} }
 
 [features]
 default = ["{{default_platform}}"]
+bundle = []
 {%- for feature in features %}
 {{ feature }}
 {%- endfor %}

--- a/Bare-Bones/src/main.rs
+++ b/Bare-Bones/src/main.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(feature = "bundle", windows_subsystem = "windows")]
 use dioxus::prelude::*;
 
 {% if is_router %}
@@ -30,10 +31,10 @@ fn App() -> Element {
         document::Link { rel: "stylesheet", href: MAIN_CSS } {% if is_tailwind -%}
         document::Link { rel: "stylesheet", href: TAILWIND_CSS } {%- endif %}
         {% if is_router -%} Router::<Route> {}
-        {%- else -%} 
+        {%- else -%}
         Hero {}
         {% if is_fullstack -%} Echo {} {%- endif %}
-        {%- endif %} 
+        {%- endif %}
     }
 }
 

--- a/Jumpstart/Cargo.toml
+++ b/Jumpstart/Cargo.toml
@@ -11,6 +11,7 @@ dioxus = { {{ dioxus_dep_src }}, features = {{dioxus_dep_features}} }
 
 [features]
 default = ["{{default_platform}}"]
+bundle = []
 {%- for feature in features %}
 # The feature that are only required for the {{feature}} build target should be optional and only enabled in the {{feature}} feature
 {{ feature }}

--- a/Jumpstart/src/main.rs
+++ b/Jumpstart/src/main.rs
@@ -1,3 +1,5 @@
+// Hide the console window on Windows when building with the "bundle" feature
+#![cfg_attr(feature = "bundle", windows_subsystem = "windows")]
 // The dioxus prelude contains a ton of common items used in dioxus apps. It's a good idea to import wherever you
 // need dioxus
 use dioxus::prelude::*;
@@ -21,7 +23,7 @@ mod views;
 
 /// The Route enum is used to define the structure of internal routes in our app. All route enums need to derive
 /// the [`Routable`] trait, which provides the necessary methods for the router to work.
-/// 
+///
 /// Each variant represents a different URL pattern that can be matched by the router. If that pattern is matched,
 /// the components for that route will be rendered.
 #[derive(Debug, Clone, Routable, PartialEq)]
@@ -60,7 +62,7 @@ fn main() {
 
 /// App is the main component of our app. Components are the building blocks of dioxus apps. Each component is a function
 /// that takes some props and returns an Element. In this case, App takes no props because it is the root of our app.
-/// 
+///
 /// Components should be annotated with `#[component]` to support props, better error messages, and autocomplete
 #[component]
 fn App() -> Element {

--- a/Workspace/packages/desktop/Cargo.toml
+++ b/Workspace/packages/desktop/Cargo.toml
@@ -9,6 +9,7 @@ ui = { workspace = true }
 
 [features]
 default = [{% if is_fullstack == false -%}"desktop"{%- endif %}]
+bundle = []
 desktop = ["dioxus/desktop"]
 {% if is_fullstack -%}
 server = ["dioxus/server", "ui/server"]

--- a/Workspace/packages/desktop/src/main.rs
+++ b/Workspace/packages/desktop/src/main.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(feature = "bundle", windows_subsystem = "windows")]
 use dioxus::prelude::*;
 
 {% if is_router -%}


### PR DESCRIPTION
Applies the flag we recommend in the docs ([here](https://dioxuslabs.com/learn/0.6/cookbook/publishing/#preparing-your-application-for-bundling)) to hide the windows console when you bundle your app to the template

Fixes [#4835](https://github.com/DioxusLabs/dioxus/issues/4835)