### PR TITLE
Use use_resource in Jumpstart echo example

### DIFF
--- a/Jumpstart/src/components/echo.rs
+++ b/Jumpstart/src/components/echo.rs
@@ -10,7 +10,12 @@ pub fn Echo() -> Element {
     //
     // use_signal is a hook that creates a state for the component. It takes a closure that returns the initial value of the state.
     // The state is automatically tracked and will rerun any other hooks or components that read it whenever it changes.
-    let mut response = use_signal(|| String::new());
+    let mut input = use_signal(|| String::new());
+
+    // TODO: Explain use_resource here.
+    let echo = use_resource(move || async move {
+        echo_server(input()).await.unwrap()
+    });
 
     rsx! {
         document::Link { rel: "stylesheet", href: ECHO_CSS }
@@ -20,25 +25,19 @@ pub fn Echo() -> Element {
             h4 { "ServerFn Echo" }
             input {
                 placeholder: "Type here to echo...",
-                // `oninput` is an event handler that will run when the input changes. It can return either nothing or a future
-                // that will be run when the event runs.
-                oninput:  move |event| async move {
-                    // When we call the echo_server function from the client, it will fire a request to the server and return
-                    // the response. It handles serialization and deserialization of the request and response for us.
-                    let data = echo_server(event.value()).await.unwrap();
-
-                    // After we have the data from the server, we can set the state of the signal to the new value.
-                    // Since we read the `response` signal later in this component, the component will rerun.
-                    response.set(data);
+                // `oninput` is an event handler that will run when the input changes.
+                // It can return either nothing or a future that will be run when the event runs.
+                oninput:  move |event| {
+                    input.set(event.value());
                 },
             }
 
             // Signals can be called like a function to clone the current value of the signal
-            if !response().is_empty() {
+            // Since we read the signal inside this component, the component "subscribes" to the signal. Whenever
+            // the signal changes, the component will rerun.
+            if let Some(response) = echo() {
                 p {
                     "Server echoed: "
-                    // Since we read the signal inside this component, the component "subscribes" to the signal. Whenever
-                    // the signal changes, the component will rerun.
                     i { "{response}" }
                 }
             }


### PR DESCRIPTION
Needs an explainer comment for use_resource, but it feels unidiomatic to teach people to use async server functions inline in an `oninput` handler nowadays, instead of using a signal + `use_resource` (the default implementation here could race, if used for anything more complex?)