### PR TITLE
add missing bundle configuration

### DIFF
--- a/Bare-Bones/Dioxus.toml
+++ b/Bare-Bones/Dioxus.toml
@@ -20,3 +20,7 @@ script = []
 # Javascript code file
 # serve: [dev-server] only
 script = []
+
+[bundle]
+identifier = "com.mycompany"
+publisher = "MyCompany"

--- a/Jumpstart/Dioxus.toml
+++ b/Jumpstart/Dioxus.toml
@@ -20,3 +20,7 @@ script = []
 # Javascript code file
 # serve: [dev-server] only
 script = []
+
+[bundle]
+identifier = "com.mycompany"
+publisher = "MyCompany"


### PR DESCRIPTION
Supersedes #58.

Currently, the user isn't asked for bundle related values and it doesn't seem critical to do so. They can be always changed after the fact, and now by default `dx bundle` doesn't trigger an error (https://github.com/DioxusLabs/dioxus/issues/3111) about the missing bundle config. Just `dx init && dx bundle` works.
