### PR TITLE
Use Rust edition 2024 for new dioxus apps

### DIFF
--- a/Bare-Bones/Cargo.toml
+++ b/Bare-Bones/Cargo.toml
@@ -2,7 +2,7 @@
 name = "{{project-name}}"
 version = "0.1.0"
 authors = ["{{authors}}"]
-edition = "2021"
+edition = "2024"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/Jumpstart/Cargo.toml
+++ b/Jumpstart/Cargo.toml
@@ -2,7 +2,7 @@
 name = "{{project-name}}"
 version = "0.1.0"
 authors = ["{{authors}}"]
-edition = "2021"
+edition = "2024"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/Workspace/packages/api/Cargo.toml
+++ b/Workspace/packages/api/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "api"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 dioxus = { workspace = true, features = ["fullstack"] }

--- a/Workspace/packages/desktop/Cargo.toml
+++ b/Workspace/packages/desktop/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "desktop"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 dioxus = { workspace = true, features = [{{- dioxus_features -}}] }

--- a/Workspace/packages/mobile/Cargo.toml
+++ b/Workspace/packages/mobile/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mobile"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 dioxus = { workspace = true, features = [{{- dioxus_features -}}] }

--- a/Workspace/packages/ui/Cargo.toml
+++ b/Workspace/packages/ui/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ui"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 dioxus = { workspace = true }

--- a/Workspace/packages/web/Cargo.toml
+++ b/Workspace/packages/web/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "web"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 dioxus = { workspace = true, features = [{{- dioxus_features -}}] }


### PR DESCRIPTION
## Summary

Updates all templates (`Bare-Bones`, `Jumpstart`, and every `Workspace` package) from Rust edition 2021 to edition 2024, so projects created with `dx new` start on the latest edition.

Fixes DioxusLabs/dioxus#5408

## Why this is safe for v0.8

- Edition 2024 requires Rust 1.85, which is already the MSRV (`rust-version`) of the dioxus 0.8 workspace — no effective toolchain bump for users.
- The dioxus repo itself is already on edition 2024.
- The template code contains no edition-sensitive patterns (no `unsafe`, `static mut`, `extern` blocks, or `gen`/`try` identifiers).

## Verification

Generated all three sub-templates locally with `cargo generate` from this branch and ran `cargo check` on each (Bare-Bones with web default, Jumpstart fullstack+router defaults, and the full Workspace) against `dioxus 0.8.0-alpha.0` — all compile cleanly on edition 2024.

## Note on backporting to v0.7

Cherry-picking this to the `v0.7` branch would also work, but dioxus 0.7.x declares `rust-version = "1.83"`, so edition 2024 templates would implicitly require Rust 1.85 for newly generated 0.7 apps. Happy to open that PR too if you want it.