### PR TITLE
fix: use Rust edition 2024 in dx new templates

### DIFF
--- a/Bare-Bones/Cargo.toml
+++ b/Bare-Bones/Cargo.toml
@@ -2,7 +2,7 @@
 name = "{{project-name}}"
 version = "0.1.0"
 authors = ["{{authors}}"]
-edition = "2021"
+edition = "2024"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/Jumpstart/Cargo.toml
+++ b/Jumpstart/Cargo.toml
@@ -2,7 +2,7 @@
 name = "{{project-name}}"
 version = "0.1.0"
 authors = ["{{authors}}"]
-edition = "2021"
+edition = "2024"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/Workspace/packages/api/Cargo.toml
+++ b/Workspace/packages/api/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "api"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 dioxus = { workspace = true, features = ["fullstack"] }

--- a/Workspace/packages/desktop/Cargo.toml
+++ b/Workspace/packages/desktop/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "desktop"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 dioxus = { workspace = true, features = [{{- dioxus_features -}}] }

--- a/Workspace/packages/mobile/Cargo.toml
+++ b/Workspace/packages/mobile/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mobile"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 dioxus = { workspace = true, features = [{{- dioxus_features -}}] }

--- a/Workspace/packages/ui/Cargo.toml
+++ b/Workspace/packages/ui/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ui"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 dioxus = { workspace = true }

--- a/Workspace/packages/web/Cargo.toml
+++ b/Workspace/packages/web/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "web"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 dioxus = { workspace = true, features = [{{- dioxus_features -}}] }


### PR DESCRIPTION
## Summary

`dx new` still scaffolds projects with `edition = "2021"`. This updates the Bare-Bones, Jumpstart, and Workspace package manifests to `edition = "2024"`.

Fixes DioxusLabs/dioxus#5408

## Test plan

- [ ] Confirm Cargo.toml files under Bare-Bones, Jumpstart, and Workspace/packages use edition 2024
- [ ] `dx new` against the v0.7 template branch produces edition 2024