### PR TITLE
feat: add TOML schema comment to Dioxus.toml templates

### DIFF
--- a/Bare-Bones/Dioxus.toml
+++ b/Bare-Bones/Dioxus.toml
@@ -1,3 +1,5 @@
+#:schema https://raw.githubusercontent.com/DioxusLabs/dioxus/main/packages/cli/schema.json
+
 [application]
 
 

--- a/Jumpstart/Dioxus.toml
+++ b/Jumpstart/Dioxus.toml
@@ -1,3 +1,5 @@
+#:schema https://raw.githubusercontent.com/DioxusLabs/dioxus/main/packages/cli/schema.json
+
 [application]
 
 


### PR DESCRIPTION
## Summary

Adds the `#:schema` line pointing at the CLI schema so editors can offer completions for `Dioxus.toml` in Bare-Bones and Jumpstart templates.

Fixes DioxusLabs/dioxus#5376

## Test plan

- [ ] New projects from Bare-Bones / Jumpstart include the schema comment at the top of Dioxus.toml